### PR TITLE
Don't locate DbContexts and DbMigrationsConfigurations that cannot be constructed

### DIFF
--- a/src/Migrator.EF6.Tools/Executor.cs
+++ b/src/Migrator.EF6.Tools/Executor.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using Microsoft.DotNet.ProjectModel;
+using Migrator.EF6.Tools.Extensions;
 
 namespace Migrator.EF6.Tools
 {
@@ -68,10 +69,7 @@ namespace Migrator.EF6.Tools
 		private string FindAppDbContextTypeName()
 		{
 			var allDbContextTypes = _types.Where(
-				t => typeof(DbContext).IsAssignableFrom(t)
-					 && t.GetConstructor(BindingFlags.Instance | BindingFlags.Public, null, Type.EmptyTypes, null) != null
-					 && !t.IsAbstract
-					 && !t.IsGenericType);
+				t => typeof(DbContext).IsAssignableFrom(t) && t.IsConstructable());
 			var dbContextType = allDbContextTypes.FirstOrDefault();
 			return dbContextType?.Name;
 		}
@@ -190,10 +188,7 @@ namespace Migrator.EF6.Tools
 		private DbMigrationsConfiguration FindDbMigrationsConfiguration()
 		{
 			var configType = _types.Where(
-					t => typeof(DbMigrationsConfiguration).IsAssignableFrom(t)
-						 && t.GetConstructor(BindingFlags.Instance | BindingFlags.Public, null, Type.EmptyTypes, null) != null
-						 && !t.IsAbstract
-						 && !t.IsGenericType)
+					t => typeof(DbMigrationsConfiguration).IsAssignableFrom(t) && t.IsConstructable())
 				.FirstOrDefault();
 			var config = Activator.CreateInstance(configType) as DbMigrationsConfiguration;
 			return config;

--- a/src/Migrator.EF6.Tools/Executor.cs
+++ b/src/Migrator.EF6.Tools/Executor.cs
@@ -67,7 +67,11 @@ namespace Migrator.EF6.Tools
 
 		private string FindAppDbContextTypeName()
 		{
-			var allDbContextTypes = _types.Where(t => typeof(DbContext).IsAssignableFrom(t));
+			var allDbContextTypes = _types.Where(
+				t => typeof(DbContext).IsAssignableFrom(t)
+					 && t.GetConstructor(BindingFlags.Instance | BindingFlags.Public, null, Type.EmptyTypes, null) != null
+					 && !t.IsAbstract
+					 && !t.IsGenericType);
 			var dbContextType = allDbContextTypes.FirstOrDefault();
 			return dbContextType?.Name;
 		}
@@ -185,8 +189,11 @@ namespace Migrator.EF6.Tools
 
 		private DbMigrationsConfiguration FindDbMigrationsConfiguration()
 		{
-			var configType = _types
-				.Where(t => typeof(DbMigrationsConfiguration).IsAssignableFrom(t))
+			var configType = _types.Where(
+					t => typeof(DbMigrationsConfiguration).IsAssignableFrom(t)
+						 && t.GetConstructor(BindingFlags.Instance | BindingFlags.Public, null, Type.EmptyTypes, null) != null
+						 && !t.IsAbstract
+						 && !t.IsGenericType)
 				.FirstOrDefault();
 			var config = Activator.CreateInstance(configType) as DbMigrationsConfiguration;
 			return config;

--- a/src/Migrator.EF6.Tools/Extensions/TypeExtensions.cs
+++ b/src/Migrator.EF6.Tools/Extensions/TypeExtensions.cs
@@ -1,0 +1,25 @@
+﻿#if NET451
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace Migrator.EF6.Tools.Extensions
+{
+	public static class TypeExtensions
+	{
+		/// <summary>
+		/// Checks if the type has a public constructor with no parameters, and is constructable (is not abstract and not a generic type).
+		/// </summary>
+		public static bool IsConstructable(this Type type)
+		{
+			return type.GetConstructor(BindingFlags.Instance | BindingFlags.Public, null, Type.EmptyTypes, null) != null
+				   && !type.IsAbstract
+				   && !type.IsGenericType;
+		}
+	}
+}
+
+#endif


### PR DESCRIPTION
When an abstract (or generic) base class is made for either types, they might be used, instead of the implementation.

Example: I have an abstract class DbContextBase and a class MyApplicationContext : DbContextBase.
Migrator.EF6 would incorrectly detect DbContextBase as the single true DbContext, instead of MyApplicationContext.

The constraint I've used are taken from the [EF source code](https://entityframework.codeplex.com/SourceControl/latest#src/EntityFramework/Migrations/Utilities/MigrationsConfigurationFinder.cs)
