### PR TITLE
Fixed issue where MigrationsDirectory property in DbMigrationConfiguration was ignored.

### DIFF
--- a/src/Migrator.EF6.Tools/Executor.cs
+++ b/src/Migrator.EF6.Tools/Executor.cs
@@ -74,9 +74,9 @@ namespace Migrator.EF6.Tools
 
 		public void AddMigration(string name, string outputDir, bool ignoreChanges)
 		{
-			var migrationsDir = GetMigrationsDir(outputDir);
-			Directory.CreateDirectory(migrationsDir);
 			var config = FindDbMigrationsConfiguration();
+			var migrationsDir = GetMigrationsDir(outputDir ?? config.MigrationsDirectory);
+			Directory.CreateDirectory(migrationsDir);
 
 			// Scaffold migration.
 			var scaffolder = new MigrationScaffolder(config);


### PR DESCRIPTION
It's possible to set a folder where migrations should be created by default in the DbMigrationConfiguration class. This property was ignored by Migrator.EF6.
